### PR TITLE
support ATT (#3) and redo stepping code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# https://editorconfig.org/
+root = yes
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Now you can pass an ATT file directly to the constructor and it will parse it for you.

To implement undo you just need to store the `ctx` objects that `step()` returns and for weights you just need to change the type signature from (in C++ terms) `map<State, vector<string>>` to `map<State, vector<pair<string, double>>>` (which affects the concatenation logic in `epsilon_closure()` and `_product()` but not really anything else).